### PR TITLE
fix : Feed Screen loading

### DIFF
--- a/app/src/main/java/com/knu/quickthink/QuickThinkApp.kt
+++ b/app/src/main/java/com/knu/quickthink/QuickThinkApp.kt
@@ -75,7 +75,11 @@ fun QuickThinkApp(
                     QuickThinkTopAppBar(
                         isMainRoute = appState.isMainRoute.value,
                         menuExpanded = appState.menuExpanded,
-                        onLogoClicked = { appState.navController.navigate(MainDestination.MAIN_ROUTE) },
+                        onLogoClicked = {
+                            if(!appState.isFeedRoute.value){
+                                appState.navController.navigate(MainDestination.MAIN_ROUTE)
+                            }
+                        },
                         onSearchClicked = {
                             appState.navController.navigate(MainDestination.SERACH_ROUTE)
                         },
@@ -85,7 +89,7 @@ fun QuickThinkApp(
                     )
                 },
                 floatingActionButton = {
-                    if (appState.isMyFeedScreen) {
+                    if (appState.isFeedRoute.value) {
                         FABContent {
                             val cardId : Long = -1
                             appState.navController.navigate("${MainDestination.CARD_EDIT_ROUTE}/$cardId")

--- a/app/src/main/java/com/knu/quickthink/QuickThinkAppState.kt
+++ b/app/src/main/java/com/knu/quickthink/QuickThinkAppState.kt
@@ -30,9 +30,10 @@ fun rememberQuickThinkAppState(
     },
     coroutineScope :CoroutineScope = rememberCoroutineScope(),
     isMainRoute : MutableState<Boolean> = remember { mutableStateOf(false)},
+    isFeedRoute : MutableState<Boolean> = remember { mutableStateOf(false)},
     menuExpanded : MutableState<Boolean> = remember { mutableStateOf(false)},
 ) = remember(navController,bottomSheetNavigator,coroutineScope,sheetState,feedScreenState,isMainRoute,menuExpanded){
-    QuickThinkAppState(navController,bottomSheetNavigator,coroutineScope,sheetState,feedScreenState,isMainRoute,menuExpanded)
+    QuickThinkAppState(navController,bottomSheetNavigator,coroutineScope,sheetState,feedScreenState,isMainRoute,isFeedRoute,menuExpanded)
 }
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterialNavigationApi::class)
@@ -43,6 +44,7 @@ class QuickThinkAppState(
     val sheetState : ModalBottomSheetState,
     val feedScreenState : FeedScreenState,
     val isMainRoute : MutableState<Boolean>,
+    val isFeedRoute : MutableState<Boolean>,
     val menuExpanded : MutableState<Boolean>,
 ) {
     fun addDestinationChangedListener(
@@ -54,6 +56,7 @@ class QuickThinkAppState(
             }else if(isMainRoute.value && !destination.route!!.contains("main")){
                 isMainRoute.value = false
             }
+            isFeedRoute.value = destination.route!! == MainDestination.FEED_ROUTE
         }
         navController.addOnDestinationChangedListener(callback)
     }

--- a/app/src/main/java/com/knu/quickthink/screens/feed/FeedViewModel.kt
+++ b/app/src/main/java/com/knu/quickthink/screens/feed/FeedViewModel.kt
@@ -30,7 +30,7 @@ class FeedViewModel @Inject constructor(
     private val cardRepository: CardRepository,
 ): ViewModel(){
 
-    private val _uiState = MutableStateFlow(FeedUiState())
+    private val _uiState = MutableStateFlow(FeedUiState(isLoading = true))
     val uiState :StateFlow<FeedUiState> = _uiState.asStateFlow()
 
     fun fetchContent(){


### PR DESCRIPTION
## Summary
* [x] TopAppBar의 QuickThink 로고 클릭 시 FeedScreen으로 계속 navigate하는 버그 해결
* [x] FeedScreen Loading할 때 잠깐 카드가 없다는 결과 보여주는 버그 해결